### PR TITLE
gh pages ready

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
+  "homepage": "https://coryfitz.github.io/",
   "packages": {
     "": {
       "name": "england_counties",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d build"
   },
   "eslintConfig": {
     "extends": [

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Page Not Found</title>
+    <script>
+      sessionStorage.redirect = location.href;
+    </script>
+    <meta http-equiv="refresh" content="0;URL='/'" />
+  </head>
+  <body>
+    <h1 style="text-align: center;">Redirecting...</h1>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -40,6 +40,15 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+  <script>
+    (function () {
+      const redirect = sessionStorage.redirect;
+      delete sessionStorage.redirect;
+      if (redirect && redirect !== location.href) {
+        history.replaceState(null, null, redirect);
+      }
+    })();
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
followed from https://github.com/gitname/react-gh-pages onwards

$ npm install gh-pages --save-dev

$ npm run deploy

configure https://github.com/username/username.github.io/settings/pages to run from new gh-pages branch

added 404 code to redirect to correct page as workaround for GitHub pages handling single-age apps

